### PR TITLE
Bind cider-refresh to C-c k.

### DIFF
--- a/home/.emacs.d/init.el
+++ b/home/.emacs.d/init.el
@@ -190,7 +190,8 @@
 (add-hook 'cider-mode-hook (lambda ()
                              (cider-turn-on-eldoc-mode)
                              (paredit-mode +1)
-                             (fix-paredit-repl)))
+                             (fix-paredit-repl)
+                             (local-set-key (kbd "C-c k") 'cider-refresh)))
 (add-hook 'cider-mode-hook 'company-mode)
 
 (add-hook 'cider-repl-mode-hook 'paredit-mode)
@@ -308,3 +309,4 @@ Display the results in a hyperlinked *compilation* buffer."
   (switch-to-buffer (make-temp-name "scratch")))
 
 (load-system-specific-configs "-after")
+


### PR DESCRIPTION
Cider refresh uses tools.namespace to refresh your repl state. This is
the same method lein-test-refresh uses to refresh state. It leaves you
in a better state than the usual full buffer eval as it reloads
namespaces that are affected by the change and clears local state.
